### PR TITLE
Multi PK check, overwrite collation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # Copyright 2018, David Berube. All rights reserved.
 # See LICENSE for license details.
 
-ruby '2.5.1'
+ruby '2.5.5'
 
 source 'https://rubygems.org'
 gem 'mysql2'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # Copyright 2018, David Berube. All rights reserved.
 # See LICENSE for license details.
 
-ruby '2.4.1'
+ruby '2.5.1'
 
 source 'https://rubygems.org'
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.10)
-      activesupport (= 4.2.10)
-      builder (~> 3.1)
-    activerecord (4.2.10)
-      activemodel (= 4.2.10)
-      activesupport (= 4.2.10)
-      arel (~> 6.0)
-    activesupport (4.2.10)
-      i18n (~> 0.7)
+    activemodel (5.2.3)
+      activesupport (= 5.2.3)
+    activerecord (5.2.3)
+      activemodel (= 5.2.3)
+      activesupport (= 5.2.3)
+      arel (>= 9.0)
+    activesupport (5.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (6.0.4)
-    builder (3.2.3)
+    arel (9.0.0)
     coderay (1.1.2)
-    i18n (0.8.6)
-    method_source (0.9.0)
-    minitest (5.10.3)
-    mysql2 (0.4.10)
-    pry (0.11.3)
+    concurrent-ruby (1.1.5)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    method_source (0.9.2)
+    minitest (5.11.3)
+    mysql2 (0.5.2)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     ptools (1.3.5)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -38,7 +38,7 @@ DEPENDENCIES
   ptools
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Usage: mysql_change_database_encoding.rb [options]
         --[no-]direct-alter-table    If necessary, issue direct ALTER TABLE statements without OSC. This is use if pt_online_schema_change is not installed, if --no-osc is passed, or if a table does not have a primary key.
         --[no-]osc                   Enables online schema change using pt-online-schema-change. Defaults to true if pt-online-schema-change is installed.
         --osc-options [OPTIONS]      Sets optional parameters for pt-online-schema-change, which are passed on as-is.
+    -o, --overwrite                  Optional parameter to overwrite the collation even if it is already migrated.
         --[no-]skip-table-on-error   If a SQL error, continue to next table; if not set, quit on SQL errors. Defaults to false. 
     -v, --verbose                    Run with more output.
 ```

--- a/lib/database_encoding_changer.rb
+++ b/lib/database_encoding_changer.rb
@@ -111,6 +111,7 @@ class DatabaseEncodingChanger
     cmd << Shellwords.escape(sql) 
     cmd << ' '
     cmd << Shellwords.escape(pt_dsn(table))
+    puts cmd
     system cmd
 
     

--- a/lib/database_encoding_changer.rb
+++ b/lib/database_encoding_changer.rb
@@ -144,8 +144,24 @@ class DatabaseEncodingChanger
       puts msg
     end
   end
+
   def table_list
-    conn.execute("SELECT table_name FROM information_schema.tables where table_type = 'BASE TABLE' AND table_schema=#{conn.quote(@options[:database])};").to_a.flatten
+<<<<<<< HEAD
+    if @options[:overwrite]
+      conn.execute("SELECT table_name FROM information_schema.tables WHERE
+                    table_type = 'BASE TABLE'
+                    AND table_schema=#{conn.quote(@options[:database])}
+                    ;").to_a.flatten
+    else
+      conn.execute("SELECT table_name FROM information_schema.tables WHERE
+                    table_type = 'BASE TABLE'
+                    AND table_schema=#{conn.quote(@options[:database])}
+                    AND table_collation <> #{conn.quote(@options[:collation])}
+                    ;").to_a.flatten
+    end
+=======
+    ActiveRecord::Base.connection.tables
+>>>>>>> parent of c3b6208... change DatabaseEncodingChange#tables method to avoid trying to migrate views
   end
 
   def conn

--- a/lib/database_encoding_changer.rb
+++ b/lib/database_encoding_changer.rb
@@ -146,7 +146,6 @@ class DatabaseEncodingChanger
   end
 
   def table_list
-<<<<<<< HEAD
     if @options[:overwrite]
       conn.execute("SELECT table_name FROM information_schema.tables WHERE
                     table_type = 'BASE TABLE'
@@ -159,9 +158,6 @@ class DatabaseEncodingChanger
                     AND table_collation <> #{conn.quote(@options[:collation])}
                     ;").to_a.flatten
     end
-=======
-    ActiveRecord::Base.connection.tables
->>>>>>> parent of c3b6208... change DatabaseEncodingChange#tables method to avoid trying to migrate views
   end
 
   def conn

--- a/lib/database_encoding_changer_table.rb
+++ b/lib/database_encoding_changer_table.rb
@@ -14,7 +14,7 @@ class DatabaseEncodingChangerTable < ActiveRecord::Base
     # If a table lacks a primary key, pt-online-schema-change will not be able to 
     # modify the table.
 
-    if self.primary_key.nil?
+    if self.primary_key.nil? and (connection.schema_cache.primary_keys(table_name).nil? or connection.schema_cache.primary_keys(table_name).empty?)
       false
     else
       true

--- a/lib/mcde_options_parser.rb
+++ b/lib/mcde_options_parser.rb
@@ -15,6 +15,7 @@ module McdeOptionsParser
     options[:osc]                 = true
     options[:osc_options]         = ''
     options[:skip_table_on_error] = false
+    options[:overwrite]           = false
 
     options[:pt_online_schema_change_path] = File.which("pt-online-schema-change") 
 
@@ -61,6 +62,10 @@ module McdeOptionsParser
         end
         opts.on("--osc-options [OPTIONS]", "Sets optional parameters for pt-online-schema-change, which are passed on as-is.") do |_|
           options[:osc_options] = _
+        end
+
+        opts.on("-o", "--overwrite" ,"Optional parameter to overwrite the collation even if it is already migrated.") do |_|
+          options[:overwrite] = _
         end
 
         opts.on("--[no-]skip-table-on-error", "If a SQL error, continue to next table; if not set, quit on SQL errors. Defaults to false. ") do |_|


### PR DESCRIPTION
Update dependencies so multi PKs are recognized.  Add multi PK check. Modify the default behavior to not migrate a table and its columns if the table is already at the target collation, then there is an overwrite to force the collation migration.